### PR TITLE
Support for Android 11/Magisk 21.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ Uninstall
 Changelog
 ------
 
+v.1.3.3
+- Added support for Android 11 and Magisk 21.x!
+- Updated user-agent for downloading hosts.
+- The `hitWeb` function shouldn't make you wait for long now.
+
+
 v.1.3.2
 - Added missing cut alias. (Which was breaking domain verifying functions.)
 - Fixed missing systemless hosts print.

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=energizedprotection
 name=Energized Protection
-version=1.3.2
-versionCode=200525132
+version=1.3.3
+versionCode=201015133
 author=AdroitAdorKhan
 description=Let's make an annoyance free better open internet, altogether! https://energized.pro

--- a/system/bin/energized
+++ b/system/bin/energized
@@ -8,9 +8,19 @@
 # ========================================
 
 # ----------------------------------------
+# Determine the Magisk binary's location
+# ----------------------------------------
+
+if [ -d "/sbin/.magisk" ]; then
+    magisk_sbin="/sbin/.magisk"
+elif [ -d "$(magisk --path)/.magisk" ]; then
+    magisk_sbin="$(magisk --path)/.magisk"
+fi
+
+# ----------------------------------------
 # Load setup files and strings
-[ -d "/sbin/.magisk" ] && MAGISKTMP="/sbin/.magisk" || MAGISKTMP="$(find /dev -mindepth 2 -maxdepth 2 -type d -name ".magisk")"
-modPath="$MAGISKTMP/modules/energizedprotection/system/bin"
+# ----------------------------------------
+modPath="$magisk_sbin/modules/energizedprotection/system/bin"
 . $modPath/setupFiles.sh
 . $modPath/mainMenu.sh
 . $modPath/strings.sh

--- a/system/bin/energized
+++ b/system/bin/energized
@@ -65,7 +65,7 @@ N='\e[0m' > /dev/null 2>&1; # No color
 NC='\033[0m' > /dev/null 2>&1; # printf No color
 # ----------------------------------------
 
-hitWeb() { curl -sf http://go.energized.pro/web > /dev/null 2>&1; }
+hitWeb() { curl --connect-timeout 5 -sf http://go.energized.pro/web > /dev/null 2>&1; }
 
 # ----------------------------------------
 # Mount and unmount system

--- a/system/bin/energized
+++ b/system/bin/energized
@@ -9,7 +9,8 @@
 
 # ----------------------------------------
 # Load setup files and strings
-modPath="/sbin/.magisk/modules/energizedprotection/system/bin"
+[ -d "/sbin/.magisk" ] && MAGISKTMP="/sbin/.magisk" || MAGISKTMP="$(find /dev -mindepth 2 -maxdepth 2 -type d -name ".magisk")"
+modPath="$MAGISKTMP/modules/energizedprotection/system/bin"
 . $modPath/setupFiles.sh
 . $modPath/mainMenu.sh
 . $modPath/strings.sh

--- a/system/bin/energized
+++ b/system/bin/energized
@@ -81,7 +81,7 @@ unmountSystem(){
 # ----------------------------------------
 # Variables
 # ----------------------------------------
-userAgent='Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0'
+userAgent='Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0'
 hostsGZ=$directory/hosts.gz
 versionInfo=$directory/cache/version.md
 versionBackup=$directory/cache/version.md.bck

--- a/system/bin/setupFiles.sh
+++ b/system/bin/setupFiles.sh
@@ -28,6 +28,11 @@ checkMagisk() {
             busyboxPath=/data/adb/magisk
             return 1
             ;;
+        '21'[0-9a-zA-Z]*) # Version 21.x
+            hosts=/data/adb/modules/hosts/system/etc/hosts
+            busyboxPath=/data/adb/magisk
+            return 1
+            ;;
         *)
             echo -e "\n >Version: $printMagiskVersion - not supported.\n > Exiting..."
             exit


### PR DESCRIPTION
- Fix #25 and #26 
- Update `userAgent` for downloading hosts.
- Set a timeout for our `hitWeb` function.